### PR TITLE
fix: adjusting pom.xml and path to rt.jar using java.home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,59 @@
 # TaintAnalysis
-This is a field sensitive taint analysis client implementation on top of Heros, 
+This is a field sensitive taint analysis client implementation on top of Heros,
 which uses Boomerang to resolve aliasing.
 
 ## Dependencies
-Following dependencies must be built to run the analysis.  
-- Heros: https://github.com/Sable/heros 
+Following dependencies must be built to run the analysis.
+- Heros: https://github.com/Sable/heros
 - BoomerangPDS: https://github.com/CodeShield-Security/SPDS
 
 ## How to run
-- Various test cases are listed under `test/target/taint`  
-- Run the test cases in `TaintAnalysisTest`  
+- Various test cases are listed under `test/target/taint`
+- Run the test cases in `TaintAnalysisTest`
 - sources and sinks are defined as `SootMethodRef`'s in `createAnalysisTransformer` method.
+
+## Authenticating to GitHub Packages
+
+To access the GitHub packages repository, you also need to set up GitHub credentials in your Maven's `settings.xml` file. Therefore, you need to add a `server` block with the id `github`, your username and an access token that has `package:read` rights to your `setting.xml`.
+An in-depth documentation on how to do this can be found [here](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages#authenticating-to-github-packages).
+
+
+```xml 
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/CodeShield-Security/SPDS</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>USER</username>
+      <password>TOKEN-USER</password>
+    </server>
+  </servers>
+</settings>
+
+```

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>de.upb.cs.swt</groupId>
             <artifactId>heros</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>boomerangPDS</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/test/java/test/base/IFDSTestSetUp.java
+++ b/src/test/java/test/base/IFDSTestSetUp.java
@@ -44,8 +44,10 @@ public abstract class IFDSTestSetUp {
     private void setupSoot(String targetTestClassName) {
         G.reset();
         String userdir = System.getProperty("user.dir");
-		String sootCp = userdir + File.separator + "target" + File.separator + "test-classes"+ File.pathSeparator + "lib"+File.separator+"rt.jar";
-        Options.v().set_soot_classpath(sootCp);
+        String javaHome = System.getProperty("java.home");
+
+		String sootCp = userdir + File.separator + "target" + File.separator + "test-classes"+ File.pathSeparator + javaHome + File.separator +"lib"+File.separator+"rt.jar";
+		Options.v().set_soot_classpath(sootCp);
 
         // We want to perform a whole program, i.e. an interprocedural analysis.
         // We construct a basic CHA call graph for the program


### PR DESCRIPTION
1. Adjusted the pom.xml for the available versions.
2. Added some instructions to the README.
3. Modified the class src/test/java/test/base/IFDSTestSetUp.java to no longer depend on manually copying the rt.jar file. It now uses the java.home of the respective machine.